### PR TITLE
ci: add workflow_dispatch trigger for manual release testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v1.0.0). Leave empty to use the current ref.'
+        required: false
+        type: string
 
 jobs:
   release:


### PR DESCRIPTION
Allows triggering the release workflow manually from the GitHub Actions UI, making it easier to test the CurseForge upload pipeline without pushing a tag.

https://claude.ai/code/session_01HJCv7bsC12WCgjFsnkVVsE