### PR TITLE
STU-034 PR 2 — Add Tri_Tracker.md and Tri_Completed.md (additive)

### DIFF
--- a/Tri_Completed.md
+++ b/Tri_Completed.md
@@ -1,0 +1,13 @@
+# Triage — Completed Items
+
+Append-only history of completed Triage work. Active and queued items live in
+`Tri_Tracker.md`. Cross-project status rollup lives in `BawrLabs/INDEX.md`.
+
+*(No completed entries yet — Triage's prior work history lives in `BawrLabs/BACKLOG.md`
+under the Completed section, but no entries there carry the `TRI-` prefix. This file
+is created with the history footer template; entries will be appended as Triage items
+move from `Tri_Tracker.md` to here on completion.)*
+
+---
+Pre-split history: Royaleint/BawrLabs@<CUTOVER-SHA>:BACKLOG.md
+Archaeology: `git log -S "<ITEM-ID>" -- BACKLOG.md` at that SHA

--- a/Tri_Tracker.md
+++ b/Tri_Tracker.md
@@ -1,0 +1,449 @@
+# Triage — Tracker
+
+Active and queued work for the Triage addon. Completed items live in
+`Tri_Completed.md`. Cross-project status rollup lives in
+`BawrLabs/INDEX.md`.
+
+## Backlog
+
+### Next Release
+
+*(None — populated by Rawb as scope decisions are made.)*
+
+### Bugs
+
+### TRI-023 Transform spell tracking (Cenarion Ward, etc.)
+- **Type:** Bug / Feature (quick win)
+- **Priority:** High
+- **Status:** Backlog
+- **Source:** ERF #77.
+- **Summary:** Some spells change name on proc (Cenarion Ward → Cenarion Ward HoT). Indicator stops tracking when the aura name no longer matches. Options: lookup table of spell → proc name, spell ID tracking, or document workaround. Spell validation (TRI-014) should warn about known transform spells.
+
+### Features
+
+### TRI-001 Boss frames as raid-style compact frames
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Backlog
+- **Summary:** Boss unit frames (Boss1–Boss5) are Blizzard's default `TargetFrame` buttons, not compact raid frames. On fights like Lura, healable adds appear in these frames and healers have no way to configure them. Supporting them would require addon-owned compact-style boss frames so they can receive Triage indicators, dispel overlay, range, and profile-driven appearance.
+- **Source:** Direct guild feedback from a healer.
+- **Research status:** Initial feasibility review complete (2026-04-06).
+- **Findings:** Retail-only and technically feasible, but not as a pure overlay feature. Blizzard's compact frame system can bind fixed unit tokens, so addon-created `CompactUnitFrameTemplate` buttons can target `boss1`–`boss5`. Blizzard arena frames prove the template supports fixed unit tokens, and Cell already ships a separate boss/NPC unit-frame surface.
+- **Constraints:** Frames must be pre-created and unit-bound out of combat, then shown/hidden with `RegisterUnitWatch` as bosses appear mid-fight. Avoid the Blizzard `Arena` compact-frame mode because its PvP-specific option path disables dispel indicators; use Party-style sizing/options or a compact setup clone instead.
+- **Triage impact:** Current architecture only iterates Blizzard raid/party compact frames and filters to `player`/`party`/`raid` units. This feature needs a managed frame registry, boss-aware iteration, and selective widening of `ShouldContinue()` rather than a small hook on the existing code.
+- **Suggested spike:** Build one Retail-only prototype frame for `boss1`, anchor it near `BossTargetFrameContainer`, and validate targeting, right-click menu, Blizzard click-casting, aura listener updates, dispel overlay, and encounter-time appearance before committing to all five frames.
+- **Notes:** High differentiator for Blizzard-frame users, but not literally unique — Cell already supports boss/NPC frames. Bigger scope than the current overlay-only healing modules. Retail only.
+
+### TRI-002 Import aura watch lists from other addons
+- **Type:** Feature
+- **Priority:** Medium
+- **Status:** Backlog
+- **Summary:** Import DandersFrames Aura Designer placed-aura configurations into Triage's 9 indicator positions as aura watch lists. This is a lossy migration tool, not a full profile import or Aura Designer compatibility layer.
+- **Data policy:** Safe. Reads user-owned DandersFrames data only: either the live `DandersFramesDB_v2` global if Danders is loaded, or a user-provided Danders export string. Does not require runtime parsing of competitor source files and does not ship competitor config semantics wholesale.
+- **Research status:** Investigated 2026-04-06 against DandersFrames' current SavedVariables and Aura Designer runtime model.
+- **Findings:** Feasible on Retail if scoped narrowly. Danders stores Aura Designer data under `DandersFramesDB_v2.profiles[profile].party/raid.auraDesigner.auras[spec]`; placed indicators live in `auraCfg.indicators[]` with `type`, `anchor`, `offsetX`, and `offsetY`. Triage stores only 9 fixed per-position watch lists (`indicator-1`..`indicator-9`), so any import is inherently lossy.
+- **Findings:** Anchor mapping is clean because both addons use the same 9-point model: `TOPLEFT`, `TOP`, `TOPRIGHT`, `LEFT`, `CENTER`, `RIGHT`, `BOTTOMLEFT`, `BOTTOM`, `BOTTOMRIGHT`. These can map directly to Triage indicator slots 1-9.
+- **Findings:** Danders Aura Designer keys are mostly internal aura IDs like `PowerWordShield`, not literal WoW aura names. Import must prefer `AuraDesigner.SpellIDs[spec][auraName]` and `AlternateSpellIDs` where available. Importing raw internal names into Triage would silently produce bad watch lists.
+- **Findings:** Triage cannot faithfully import Danders layout groups, multi-aura frame effects, sound alerts, or other Aura Designer-only semantics. Grouped indicators are stored separately via `layoutGroups[spec]` and their effective positions are computed dynamically; Triage has no equivalent grouping or growth model. These should be skipped in v1.
+- **Findings:** Danders also supports secret, inferred, and self-only aura systems that exceed Triage's current matcher. Examples include secret aura fingerprints, linked aura inference, and self-only spell handling. These entries should be skipped or clearly warned about during import rather than copied blindly.
+- **Findings:** Multiple Danders auras can occupy the same anchor. Triage can only show one active aura per slot, so same-anchor imports should become ordered watch lists in a single Triage slot rather than attempting visual parity. Use Danders aura priority to order collisions where possible.
+- **Findings:** WoW cannot read another addon's WTF SavedVariables file from disk at runtime. Clean input options are therefore: `1)` live import from `DandersFramesDB_v2` if Danders is installed and loaded, or `2)` pasted Danders export text. Supporting Danders export text is feasible, but Triage would need to parse Danders' `!DFP1!` format, which currently uses `LibSerialize` + `LibDeflate` rather than Triage's existing `AceSerializer` import path.
+- **Recommended v1 scope:** Retail only. Select one Danders profile, one mode (`party` or `raid`), and one spec at a time. Import only ungrouped placed indicators (`icon`, `square`, `bar`) from supported Aura Designer specs. Resolve to spell IDs, map anchors to Triage slots, and write newline-delimited aura lists into Triage's existing indicator config.
+- **Recommended v1 scope:** Provide a preview before apply showing counts for imported entries, skipped grouped entries, skipped secret or inferred entries, unsupported entries, and per-slot anchor collisions. Offer merge vs overwrite behavior per target slot so the tool does not unexpectedly destroy an existing Triage setup.
+- **Non-goals:** No full Danders profile import. No recreation of layout groups. No translation of frame-level effects such as border, health bar color, text color, frame alpha, or sound. No promise of secret-aura parity.
+- **Notes:** Danders Aura Designer currently targets healer specs plus Augmentation Evoker, which limits the source surface and helps feasibility. If this importer works, the generalizable pattern is not 'import competitor profiles' but 'map another addon's anchored aura definitions into Triage's slot-based watch lists.' That same pattern could later be evaluated for Cell or VuhDo.
+
+### TRI-005 Built-in click-casting
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Research Complete, Spike Defined
+- **Summary:** Compiled macro click-casting system. Harm/help conditionals, Smart Resurrection, per-spec defaults. Retail + Classic support. Feasibility spike required before full implementation. GitHub issue #5.
+
+### TRI-006 Curated per-spec aura defaults
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Backlog (data authoring assigned to Codex, issue #10)
+- **Summary:** Pre-configured aura watch lists for 7 healer specs + utility dispellers. Paired with click-casting defaults for out-of-box experience. GitHub issue #7.
+
+### TRI-008 Auto layout switching — content-aware profile selection
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Backlog
+- **Source:** Competitor analysis (Danders), ERF #58. 4 users +1'd on ERF over multiple years.
+- **Summary:** Auto-switch profiles based on content type and group size (dungeon, raid, BG, open world). Per-size-range profiles, auto-detection on roster/zone change, combat-safe queuing. Ships with sensible defaults (party 1-5, raid 6+). GitHub issue #14.
+
+### TRI-009 Priority-chain indicators — "show X, else Y, else Z" per slot
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Backlog
+- **Source:** Competitor analysis (VuhDo bouquet system).
+- **Summary:** Each indicator slot supports an ordered priority chain of conditions (specific aura, aura type, health threshold, aggro, role, missing buff). First match wins. Visual drag-and-drop editor, not nested dropdowns. Default profiles use simple single-aura slots — chains are opt-in.
+
+### TRI-010 Pre-configured raid debuffs with auto-detection
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Backlog
+- **Source:** Competitor analysis (Cell curated lists, Grid2 auto-detection).
+- **Summary:** Ship curated per-tier debuff lists for current content. Auto-detect unknown debuffs in combat and surface them for review post-encounter. Dedicated "raid debuff" indicator mode shows highest-priority active boss debuff without manual config. Works with priority chains (TRI-009).
+
+### TRI-011 Cluster heal finder — AoE heal target recommendation
+- **Type:** Feature
+- **Priority:** Medium
+- **Status:** Backlog
+- **Source:** Competitor analysis (VuhDo — only addon with this feature).
+- **Summary:** Highlight the best target for AoE/chain heals by detecting clusters of nearby injured players. Configurable radius, health threshold, per-spell presets. Performance-sensitive — needs throttled updates (0.2-0.5s). Uses positional data from C_Map or combat log range checks.
+
+### TRI-012 Raid tools panel — ready check, pull timer, markers, trackers
+- **Type:** Feature
+- **Priority:** Medium
+- **Status:** Backlog
+- **Source:** Competitor analysis (Cell — only raid frame addon with built-in raid tools).
+- **Summary:** Lightweight collapsible panel near raid frames. Core: ready check, raid markers, pull timer (syncs with DBM/BigWigs), battle res tracker. Extended: buff/consumable checker, interrupt tracker, cooldown tracker. Auto-appears for raid leaders/assists.
+
+### TRI-013 Pinned frames — custom frame groups for priority targets
+- **Type:** Feature
+- **Priority:** Medium
+- **Status:** Backlog
+- **Source:** Competitor analysis (VuhDo private tanks).
+- **Summary:** Pin specific players into a dedicated always-visible frame group independent of Blizzard Main Tank assignments. For assigned healing — pin co-healer, assigned tank, priority targets. Multiple named groups, drag-and-drop or right-click to pin. Depends on frame registry (TRI-004).
+
+### TRI-014 Spell validation with autocomplete in aura configuration
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Backlog
+- **Source:** Original — no competitor has this.
+- **Summary:** Real-time spell name validation and autocomplete in aura config fields. Validates against C_Spell.GetSpellInfo(), supports spell IDs and fuzzy matching ("rejuv" → "Rejuvenation"). Warning icon on typos. Eliminates the most common config error across all raid frame addons.
+
+### TRI-015 First-run experience — spec detection, welcome flow, progressive disclosure
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Backlog
+- **Source:** Original — UX strategy.
+- **Summary:** Detect class/spec on first load, apply defaults automatically, show brief dismissable tooltip. Progressive disclosure in settings: simple mode by default, advanced toggle for power users. Ship 3 preset templates (Raid Healer, Dungeon Healer, DPS Dispeller). This defines how the UX layer system manifests in the UI.
+
+### TRI-016 Buff/debuff blacklist for stock Blizzard icons
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Backlog
+- **Source:** ERF #142, #110. Most requested feature across ERF issues (3+ users over multiple years).
+- **Summary:** Granular control over which buffs/debuffs show in Blizzard's stock icon display. Blacklist mode (hide specific auras) and whitelist mode (hide all except listed). Separate lists for buffs and debuffs. Current workaround (disable all + re-add as indicators) wastes indicator slots.
+
+### TRI-017 Copy/sync indicator settings between positions
+- **Type:** Feature
+- **Priority:** Medium
+- **Status:** Backlog
+- **Source:** ERF #122.
+- **Summary:** Copy visual settings (size, text, animation, colors) from one indicator position to others. Optional sync mode to link positions. Bulk reset to defaults. Excludes aura lists (always per-position). Reduces tedium of configuring 9 positions with similar appearance.
+
+### TRI-018 Health bar color by health percentage
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Backlog
+- **Source:** ERF #135. Standard feature in VuhDo and Grid2.
+- **Summary:** Dynamically color health bars by remaining health (green → yellow → red). Options: class colors, flat custom color, or gradient. Configurable thresholds, smooth vs stepped. Coexists with debuff-type coloring (TRI-019) via priority. Uses SetStatusBarColor on frame.healthBar.
+
+### TRI-019 Frame color by debuff type
+- **Type:** Feature
+- **Priority:** Medium
+- **Status:** Backlog
+- **Source:** ERF #57. VuhDo staple feature.
+- **Summary:** Override health bar color with debuff type color when a dispellable debuff is active (Magic=blue, Curse=purple, Poison=green, Disease=brown). Configurable per type, priority when multiple active, option to limit to player-dispellable types. Complements existing dispel border/glow overlay. Toggle: border-only, bar-color-only, or both.
+
+### TRI-020 Multiple auras per indicator position
+- **Type:** Feature
+- **Priority:** Medium
+- **Status:** Backlog
+- **Source:** ERF #33.
+- **Summary:** Show multiple active matching auras at a single indicator position as stacked sub-icons (up to 4). Configurable direction (horizontal, vertical, grid). Alternative: cycle through matches on a timer. Default unchanged (first match). Partially overlaps with priority chains (TRI-009) — different use case (show everything vs show most important).
+
+### TRI-021 Extended range check beyond 40 yards
+- **Type:** Feature (quick win)
+- **Priority:** High
+- **Status:** Backlog
+- **Source:** ERF #130.
+- **Summary:** Range slider caps at 40yd but several Midnight healer spells are 45-46yd, causing false fades. Extend slider max to 60yd using LibRangeCheck-3.0's actual spell range data. Optionally auto-detect longest healing spell range. Primarily a UI slider limit change.
+
+### TRI-022 "Not mine" aura filter
+- **Type:** Feature (quick win)
+- **Priority:** Medium
+- **Status:** Backlog
+- **Source:** ERF #79.
+- **Summary:** Inverse of existing "mine only" filter — show an aura only if cast by someone else. Primary use: seeing other druids' Rejuvenation to avoid overwrites. Three-way toggle per position: All / Mine only / Not mine.
+
+### TRI-024 Finer indicator positioning increments
+- **Type:** Feature (quick win)
+- **Priority:** Low
+- **Status:** Backlog
+- **Source:** ERF #45, #47.
+- **Summary:** Position offsets use 1% increments — too coarse for precise alignment. Reduce to 0.5% or allow manual numeric input. Add per-indicator text anchor options for stack count and countdown text positioning within the icon.
+
+### TRI-025 Keep indicators visible when out of range
+- **Type:** Feature (quick win)
+- **Priority:** Low
+- **Status:** Backlog
+- **Source:** ERF #52.
+- **Summary:** When range fade is enabled, indicators fade with the health bar. Option to keep indicators at full alpha on faded frames so aura status is still visible at a glance. Simple per-profile toggle, default off.
+
+### Data
+
+*(None.)*
+
+### Maintenance
+
+*(None — TRI-004 is currently Awaiting Gate 2.)*
+
+### Stale
+
+*(None.)*
+
+## In Progress
+
+### TRI-026 Triage — ERF Reforged + Healing Addon
+- **Reclassified:** Originally logged as BL-005. Reclassified as TRI-026 in STU-023 — this is a Triage project item, not studio infrastructure.
+- **Type:** Feature
+- **Priority:** High
+- **Status:** In Progress (v1.0 scope expanded to full healing addon launch — design approved, feasibility spikes defined, Codex tasks assigned)
+- **Summary:** Market research for a potential new WoW healing addon. Midnight's API changes (WeakAuras dead, CLEU removed, secret values system) created a once-in-a-decade disruption window. DandersFrames proved a new entrant can gain 1M+ downloads by being Midnight-native.
+- **Market findings:**
+  - Current players: Cell (4.3M, strongest), VuhDo (28.2M, "archaic"), HealBot (82.4M, broken HoTs), Grid2 (14M, survived best), DandersFrames (1M, new Midnight-native), Clique (click-casting layer)
+  - WeakAuras effectively discontinued for combat data — massive gap for proc alerts, boss debuff callouts, cooldown coordination
+  - All incumbents except Grid2 were broken at Midnight launch
+  - DandersFrames: solo dev (DanderBot), open source (GitHub), Patreon-funded, **confirmed Claude Code user** (`.gitignore` excludes `CLAUDE.md`, `.claude/`, `.mcp.json`). Built fully custom frames (replace, not enhance). 531 commits, 84 releases in 4 months. Strengths: auto-switching layouts, built-in click-casting, visual aura designer, curated healer spec aura lists. Weaknesses: range bugs in combat, perf issues on group change, solo-dev risk, profile limit of 5, secret value taint fixes needed multiple iterations (v4.0.8–v4.1.1)
+- **Guild feedback (direct user research):**
+  - Boss-aware debuff priority is "pure gold" — highest value feature
+  - Cross-role dispel support needed — not just healers. Mages need obvious decurse, hybrids with dispels need "big fucking obvious YOU CAN DISPEL THIS" indicator
+  - VuhDo user likes DandersFrames' incoming cast tracking but can't figure out how to get VuhDo to do it — config complexity is a real barrier. DandersFrames actually uses a separate addon (TargetedSpells by ljosberinn) for this, not built-in
+  - Users run multiple addons because none covers everything well
+  - **Overlay vs separate frames: healers don't care** — "If you can deliver [customizability], I don't think they much care how." The separate-vs-overlay distinction is invisible to users. What matters is deep color/visual customization.
+  - **Good defaults are critical** — "nice to have would be a default starting point because some have too many options and little good to start from." Confirms config UX is the #1 barrier. Ship with curated per-spec presets, don't make users build from scratch.
+- **Differentiation opportunity:**
+  1. Midnight-native architecture (no legacy code paths)
+  2. "Enhance Blizzard frames" philosophy (overlays on CompactUnitFrame, not replacement) — no one does this well. 16+ hookable global functions available (UpdateHealth, UpdateAuras, UpdateDispellableDebuffs, etc.). Overlays are safe in combat. Follows Homestead design principles
+  3. Cross-role dispel/utility support (not healer-only) — mages, shadow priests, ret paladins, enhancement shamans all have dispels
+  4. Boss-aware debuff priority (fills WeakAuras void)
+  5. Genuinely intuitive config UX (the #1 complaint across all addons)
+  6. Accessibility as first-class design concern
+- **Key technical APIs:** SecureUnitButtonTemplate, UnitHealPredictionCalculator, C_UnitAuras, C_Secrets, C_ClickBindings, whitelisted healer spells, RegisterEventCallback, CompactUnitFrame hook system, C_UnitAuras.GetAuraDispelTypeColor, TriggerPrivateAuraShowDispelType
+- **DandersFrames v4.0 rewrite analysis (2026-03-23):**
+  - v3.x modified Blizzard CompactUnitFrames; v4.0 switched to fully custom frames via SecureGroupHeaderTemplate
+  - Drivers: (1) frames stuck/missing after roster changes, (2) taint cascades from Midnight secret values leaking through Blizzard code paths, (3) vehicle/arena frame isolation impossible while hooking shared pool, (4) test mode can't avoid protected frames, (5) secret booleans in pet range, secret strings in cross-realm names — uncontrollable when inheriting Blizzard code
+  - Key insight: taint came from inheriting Blizzard's value-handling code paths (arithmetic on secret values), NOT from visual overlays. Our overlay-only approach (child frames + hooksecurefunc) avoids this — but must never read/compare values from hooked frames that could be secret
+  - Human-designed architecture with AI-assisted implementation. Deep WoW domain knowledge, credits community techniques (Harrek's signature fingerprinting), authentic code style. AI accelerates boilerplate and iteration speed
+  - Proactive rewrite timed to Midnight launch, not driven by user complaints
+- **Blizzard API audit complete (2026-03-23):**
+  - Dispel detection: no single API — need maintained spell ID table (14 class/spec combos) + C_SpellBook.IsSpellKnown(). Match against auraData.dispelName ("Magic"/"Curse"/"Disease"/"Poison")
+  - Health bars must use StatusBar:SetValue() with secret values — no arithmetic. UnitHealPredictionCalculator mandatory (separate instances per use)
+  - Whitelisted healer spells (Rejuv, Riptide, Beacon, Atonement, etc.) return real non-secret data
+  - Boss-aware debuffs: Warcraftlogs API v2 (GraphQL) is strongest data source — query encounter abilities, analyze fight reports, ship as static dataset
+  - Incoming cast: UNIT_SPELLCAST_SENT has target name but secret in 12.0 — displayable not comparable
+  - ClickCastFrames global table is community interop convention
+  - C_DamageMeter provides built-in meter data as CLEU replacement
+- **Blizzard UI source analysis complete (2026-03-23):**
+  - CompactUnitFrame has 16+ hookable global functions (UpdateHealth, UpdateAuras, UpdateDispellableDebuffs, UpdateHealPrediction, etc.)
+  - Overlay pattern safe in combat: CreateFrame child + hooksecurefunc. Textures/fontstrings/non-secure children modifiable in combat. Only SetAttribute blocked.
+  - Blizzard already has dispelDebuffFrames (3 colored squares + border tint) — addon overlays bigger/louder visuals on top
+  - Source files need extraction: Blizzard_UnitFrame, Blizzard_CompactRaidFrames, Blizzard_CUFProfiles, Blizzard_ClickBindingUI, Blizzard_FrameXMLUtil, Blizzard_BuffFrame, Blizzard_FrameXML, Blizzard_RestrictedAddOnEnvironment, Blizzard_NamePlates, Blizzard_EditMode — via `git sparse-checkout add` on BlizzardUI repo
+- **Competitor code review complete (2026-03-23):**
+  - 6 addons reviewed from downloaded source: TargetedSpells, DandersFrames, Cell, Clique, VuhDo, HealBot
+  - TargetedSpells: proven click-through pattern (`enableMouse=false` + `propagateMouseInput="Both"`), forked LibCustomGlow for secret value safety, 0.2s delay pattern, CompactUnitFrame discovery via `CompactPartyFrame.memberUnitFrames`
+  - Cell: dispel detection via `C_Traits.GetNodeInfo()` talent introspection (better than spell ID tables), 168K lines / 144 files, no UnitHealPredictionCalculator (direct API calls instead)
+  - Clique: canonical click-casting reference. Key lesson: click-through alone is insufficient; overlays must preserve the real secure unit button, hover continuity, and Blizzard/Clique click-binding paths. `ClickCastFrames` matters for custom unit-frame addons but is only part of the interop story on Blizzard frames
+  - DandersFrames: filter fingerprinting for secret auras (4-boolean signature), 11 scattered combat-deferred flags (anti-pattern vs Clique's centralized queue), batch binding application with yield points
+  - HealBot: root cause of HoT failure found — switches from `"HELPFUL"` to `"RAID_IN_COMBAT"` filter in Midnight combat mode, dropping most HoTs
+  - VuhDo: bouquet system (composable condition chains) is genuinely innovative but intimidating UX
+- **Locked decisions (2026-03-23 end session):**
+  - Overlay-first on Blizzard frames; do not build replacement raid frames for early scope
+  - Preserve the real secure unit button. Overlay safety means click-through **and** hover continuity, not just non-clickable visuals
+  - Blizzard `C_ClickBindings` is the default click-casting path for early scope. First-party click-casting remains a possible later feature if Blizzard's system proves insufficient. Preserve external compatibility where feasible
+  - Core product wedge: boss-aware debuff priority + cross-role dispel urgency + strong defaults / accessibility
+- **Overlay PoC validation (2026-03-24 to 2026-03-25):**
+  - Standalone PoC addon built at `BawrLabs/projects/BawrHealingOverlayPoC/` with slash diagnostics and a minimal `frame.dispels`-driven visual
+  - Overlay attached correctly to real Blizzard compact party and raid frames
+  - Left-click targeting, right-click unit menus, Blizzard native click-casting, and Clicked bindings all worked through the overlay
+  - Real grouped dumps confirmed correct frame-to-unit mapping on `player`, `partyN`, and `raidN` frames
+  - Live grouped combat in LFR produced no Lua errors and no observed frame-behavior regressions
+  - Live `frame.dispels` validation passed on a real compact party frame: the PoC dispel border and top-right badge rendered correctly from Blizzard-owned state
+  - Core architecture question answered: read-only Blizzard-frame overlay is viable for early scope
+- **Early roadmap (2026-03-23):**
+  - Top 5 core features: boss-aware debuff priority, cross-role dispel urgency, additional aura layer on Blizzard raid frames, click-safe frame enhancement, strong defaults plus accessibility options
+  - Medium-tier follow-ons: targeted spell/incoming-cast alerts, enhanced health prediction emphasis, curated third-party frame support
+- **Open research:**
+  - Roster churn and frame reuse stress testing across joins, leaves, and party-to-raid conversion
+  - Decide whether first-party click-casting should ever move beyond Blizzard native support
+  - Optional: explicit Clique compatibility validation if the product wants to advertise it
+  - TargetedSpells incoming-cast detection: could be built in rather than depending on external addon
+  - Validate with real healers whether Blizzard-frame ceiling is acceptable
+  - Runtime validation of code-derived competitor behavior claims, especially the HealBot HoT filter regression explanation
+  - Name the addon and create project repo
+- **Session progress (2026-03-25):**
+  - V1 design doc updated: incoming cast awareness added as third core feature (Section 6.3), using curated boss dataset with `signalType` field (`aura` or `cast`). `CastDetector.lua` module added. Phase 3 expanded to "Boss-Aware Priority Layer" covering both debuffs and casts.
+  - Evaluated Enhanced Raid Frames (ERF) as potential project foundation — MIT licensed, 1.7M downloads, abandoned by author for Midnight. Cloned to `C:\Projects\addon-review\EnhancedRaidFrames\`. Full codebase analysis: 8 core files, ~1,200 lines, Ace3 stack, 9-position aura indicator grid, LibDispel dispel detection, CompactUnitFrame overlay with click-through. 47 open GitHub issues, no active forks. Community research confirmed the niche is unserved post-Midnight.
+  - Decision: revive ERF as the project scaffold. Keep all existing features (3x3 grid, range check, scaling, target markers, profiles, Classic support). Add healing layer as new modules on top. Port hooks for Midnight 12.0.
+  - Email sent to author (Britt W. Yazel, bwyazel@gmail.com) requesting permission to continue the project under the ERF name and CurseForge listing. Awaiting response.
+  - DevTool addon (also by brittyazel, MIT, actively maintained) downloaded for development use.
+- **Session progress (2026-03-26):**
+  - Reviewed the current discovery and design docs against the active ERF-exploration constraint. Product docs remain product-first; no adoption strategy was expanded while the owner response is still pending.
+  - Audited the local ERF clone specifically for Midnight continuation work. Main likely changes remain: TOC/interface bump, embedded library refresh, overlay mouse model rework, frame lifecycle hardening, and runtime verification of free-form aura matching under `C_Secrets`.
+  - Extended `BawrLabs/projects/erf-midnight-compatibility-analysis.md` with three follow-up findings: party-frame support is not explicit, direct frame scaling may conflict with Edit Mode ownership, and `C_Secrets` may require Blizzard-owned fallback signals rather than only a simple redaction check.
+- **Product decisions locked (2026-04-03–04):**
+  - **Name:** Triage — CurseForge listing: "Triage - Enhanced Raid Frames Reforged"
+  - **Slash commands:** `/triage`, `/tri`, `/erf` (alias)
+  - ERF fork under MIT license. Author (Britt W. Yazel) contacted 2026-03-26 (email) and again via CurseForge — no response received. Proceeding with fork and full attribution.
+  - ERF Midnight port ships as v1.0 (all legacy features preserved). Triage healing features ship in v1.1+ (design not locked yet).
+  - **Multi-version support: full support across Retail, Classic Era, and Pandaria Classic.** ERF features get equal bug fix and feature work on all clients. Triage healing layer is Retail-only (technical constraint, not policy). Classic testing is community-assisted — announcement includes open call for testers.
+  - Single addon, single CurseForge listing. Healing modules are toggleable Ace3 modules inside the same addon.
+  - Announcement tone: community revival, respectful continuation, full credit to Soyier.
+  - Design spec: `BawrLabs/projects/triage-design-spec.md`
+  - Implementation plan: `BawrLabs/projects/triage-v1-implementation-plan.md` (11 tasks, Codex-reviewed)
+  - Confirmed Midnight crash: `Overrides.lua:133` — `UnitInRange()` secret boolean taint. Fixed in plan Task 2.
+- **Setup (complete):**
+  - GitHub repo: `Royaleint/Triage` (not a fork, clean clone with attribution)
+  - Local repo at `C:\Projects\Triage\`, symlinked to WoW AddOns as `Triage`
+  - CurseForge listing created: slug `triage-erf`, icon uploaded
+  - Dev folder: `C:\Projects\Triage\Triage_Dev\` with plans, reference, session dirs
+  - All project docs copied from BawrLabs/projects/ to Triage_Dev/reference/
+- **Implementation (session 15, 2026-04-04):**
+  - Tasks 0-10 complete and pushed. Task 11 (in-game verification) remaining.
+  - Icon design finalized: anvil + medical cross + borrowed time clock (DALL-E generated)
+  - CurseForge blurb written with Soyier credit
+  - Mouse model: hybrid approach (Retail XML propagation, Classic parent-level scanning)
+  - Range fix: GetFriendMinChecker (was using MaxChecker, caused undim regression)
+  - Minimap button added (LibDBIcon + spell_holy_borrowedtime icon)
+  - Code quality drift identified in late session — documented for process improvement
+- **Session progress (2026-04-05/06, sessions 16-17):**
+  - Task 11 in-game verification COMPLETE. 10 bugs found and fixed during verification:
+    - /triage and /tri opening ESC game menu (HideUIPanel fix)
+    - TargetMarkers + AuraIndicators secret number taint on GetHeight/GetWidth/powerBar
+    - AuraListeners GetBleedList nil (LibDispel never had this method — bleed works natively on Retail)
+    - GetRaidTargetIndex returning secret number
+    - Profile switching crash on fresh/default profiles
+    - Settings panel ADDON_ACTION_BLOCKED during combat (InCombatLockdown guard)
+    - Range check undim regression (multiple iterations — final: Blizzard handles default, LibRangeCheck for custom only)
+    - Mouseover macros not working through indicators (explicit SetPropagateMouseMotion)
+    - frame.outOfRange secret boolean taint
+    - Stock aura OnShow hook self-shadowing
+  - Classic API reference created: FrameXML sparse checkout for Classic Era (1.15.8) and Pandaria Classic (5.5.3). New `classic_api_differences` tool in wow-api MCP. Backlog BL-008.
+  - Dispel overlay feature IMPLEMENTED and merged to main (feature/dispel-overlay branch):
+    - Standalone Modules/DispelOverlay.lua — edge border + glow on raid frames when player can dispel
+    - Reads frame.dispels PriorityTable (:Size() API) + LibDispel — zero secret values
+    - Hooks CompactUnitFrame_UpdateAuras (timing confirmed in-game via /tridev)
+    - 6 settings, Retail only, code review findings addressed
+  - Triage_Dev companion addon created with dev/debug slash commands (/tridev)
+  - GitHub issue templates added (bug report + feature request with Game Version field)
+  - Announcement drafts written (CurseForge, Reddit, GitHub issues) — v2, rewritten for voice
+  - LibDualSpec updated v1.27→v1.29, CallbackHandler and LibStub refreshed
+  - Triage Backlog section created with TRI- prefix (TRI-001 boss frames, TRI-002 addon import)
+  - 3 GitHub issues created: #1 boss frames, #2 addon import, #3 dispel overlay
+- **Session progress (2026-04-07, session 18):**
+  - Implemented `TRI-004` on worktree `tri-004-frame-registry` with a central managed-frame registry replacing direct compact-frame iteration. Branch commits:
+    - `445d6ff` — `refactor: add managed frame registry`
+    - `5b51eea` — `fix: support boss units and unnamed managed frames`
+  - `TRI-004` code review completed. Two findings were identified and fixed:
+    - Registry processing now defaults to registry-supported unit tokens, so managed `boss1..boss5` frames flow through existing module call sites.
+    - Indicator/listener child-frame creation is now safe on unnamed managed frames, which matters for future addon-owned boss frames.
+  - Started `TRI-003` follow-up work on worktree `tri-003-colored-dispel-glow`:
+    - `ccc2fbf` — `build: vendor LibCustomGlow for colored dispel glow`
+    - `.pkgmeta` and `Libs/embeds.xml` updated; `Libs/LibCustomGlow/` vendored
+    - Integration into `Modules/DispelOverlay.lua` remains open
+  - Reviewed and revised `Triage_Dev/plans/active/triage-v1-launch-design.md`:
+    - Default rollout state changed from global marker to profile-scoped `defaultsState`
+    - Classic Era click-casting explicitly changed to preset-based profiles (no spec auto-switch)
+    - Click-casting spike expanded to validate keyboard hover/global hovercast paths with a mouse-only v1 fallback
+  - **Release pipeline built and tested:**
+    - GitHub Actions workflow (BigWigsMods/packager@v2) — 3 game versions
+    - .pkgmeta fixed (all 25 embedded-library names corrected)
+    - X-Curse-Project-ID (1504503) and X-Wago-ID (5NR82vK3) added to TOC
+    - CurseForge webhook fixed (was pointing to Homestead project 1450714)
+    - Wago webhook confirmed working. CurseForge pending first-upload moderation.
+    - Test tag v0.0.1-test: all zips built, GitHub Release created
+  - **Click-casting research completed:** Full analysis of Blizzard C_ClickBindings, Clique v4.8, Clicked v1.17, DandersFrames click-casting module. Compiled macro approach selected (Approach B).
+  - **v1.0 scope expansion approved:** 6 launch features, 5 differentiators. Feasibility spike checklist written at `Triage_Dev/plans/active/feasibility-spikes.md`.
+  - **wow-addon-dev skill updated:** Secret value patterns, CompactUnitFrame overlay pattern, classic_api_differences reference, wipe() note, globals count fix.
+  - **New GitHub issues created:** #4-#12 covering all launch features and Codex tasks
+- **Session progress (2026-04-09/11, session 19):**
+  - Confirmed current `main` is linearized after rebase; older merge-SHA references in session docs are stale.
+  - TRI-003 is on `main` as `53807f4` and `edb877d`.
+  - TRI-004 is on `main` as `7eb36f0` and `0588c57`.
+  - TRI-007 is on `main` as `24248dd`, `ff31723`, `185c6a5`, `c93b4a3`, `886cc61`, `9e75dfa`, and `dbc1a66`.
+  - Argus QA passed on TRI-003 vendoring (WARN: ProcGlow is Retail-only, but Triage uses only ButtonGlow).
+  - Cherry-picked backlog docs from `Triage-Analysis-ERF-Issues` branch (build file regressions excluded).
+  - Added 18 new backlog items (TRI-008 through TRI-025) from ERF open issues and competitor analysis.
+  - Created 14 GitHub issues (#17-#31) to sync backlog with repo issues; created `quick-win` label.
+  - Cleaned up 3 stale remote branches (Triage, BawrLabs, Homestead) and 1 stale local branch (Homestead).
+  - Reviewed Claude Code releases v2.1.92-v2.1.98 against all CLAUDE.md files — no updates needed.
+- **Pending (next session):**
+  - Fresh in-game Retail verification of the merged TRI-003, TRI-004, and TRI-007 work.
+  - Run click-casting spike A1-A5 in-game (Retail).
+  - Run boss frame spike B1-B6 in-game (Retail).
+  - Run click-casting spike A6-A7 on Classic Era.
+  - Urgency glow data source investigation (Spike C).
+  - In-game test dispel overlay on a dispel class.
+  - CurseForge first-upload moderation — current status still unconfirmed from session sources.
+  - Update announcement drafts for expanded v1.0 scope.
+  - Clean up v0.0.1-test tag/release after CurseForge approves.
+  - Remove stale worktrees (`tri-003-colored-dispel-glow`, `tri-004-frame-registry`) after in-game verification.
+  - Classic Era testing (community-assisted).
+- **ERF Midnight compatibility analysis (2026-03-25):**
+  - Full analysis at `BawrLabs/projects/erf-midnight-compatibility-analysis.md`
+  - Not a rewrite — port plus two structural fixes (overlay mouse model rework, frame lifecycle hooks) and one verification gate (aura matching under C_Secrets)
+  - Pre-existing bugs found: glow API deprecated in 11.1.7 (silent failure), mineOnly precedence bug
+  - Multi-client: must maintain Classic Era, Cata/Pandaria Classic, and Retail. Healing layer Retail-only. Classic paths are frozen.
+  - Cross-promotion opportunity: ERF users are self-selected Blizzard-frame-enhancement users — natural Homestead audience
+- **PTR 12.0.5 API findings (2026-03-25):**
+  - `C_HousingCatalog` — 36 members. New function: `GetAllVariantInfosForEntry` (dye variant consolidation API). All existing safe calls still present.
+  - `C_HousingDecor` — 31 members, no visible changes.
+  - `C_CatalogShop` — 38 members.
+  - `C_HousingPhotoSharing` — nil (not available yet).
+  - `GetAllFilterTagGroups` returned 5 groups (was 6 in earlier reference) — Theme, Expansion, Style, Culture, Size. Needs diff against live.
+  - Discovery scanner: maxRecordID 4562, ~712 items (live: 4562, ~711). Only +1 item on PTR so far — 317 datamined items not yet in catalog API.
+  - Housing panel not available on PTR without a house — CatalogOverlay visual testing deferred to live or later PTR build.
+- **Project documents:**
+  - `BawrLabs/projects/healing-addon-discovery.md` — Product discovery document (strategic, Codex-verified)
+  - `BawrLabs/projects/healing-addon-design-v1.md` — Draft product design for the first real addon version after PoC validation
+  - `BawrLabs/projects/healing-addon-architecture-analysis.md` — Competitive architecture analysis (technical reference, 12 cross-cutting sections + addon profiles + anti-patterns + quick-reference tables)
+  - `BawrLabs/projects/healing-addon-feature-priorities.md` — Ranked user-facing feature priorities and competitor strengths
+  - `BawrLabs/projects/healer_roadmap_featsV0.md` — Early feature roadmap (top 5 core features + 3 medium-tier follow-ons)
+  - `BawrLabs/projects/healing-addon-poc-spec.md` — PoC scope, acceptance criteria, and validation result
+  - `BawrLabs/projects/erf-midnight-compatibility-analysis.md` — ERF Midnight port analysis (Claude + Codex findings)
+  - `BawrLabs/projects/BawrHealingOverlayPoC/` — Standalone overlay viability addon used for in-game testing
+  - `Homestead/Home_Dev/reference/HEALING_ADDON_ARCHITECTURE_REVIEW.md` — Raw all-in-one review (supplementary)
+  - Blizzard UI source extracted at `C:\Projects\BlizzardUI\` (10 healing-related directories via sparse checkout)
+  - Competitor addon source copied to `C:\Projects\addon-review\` for reference (7 addons, including ERF)
+- **Notes:** Separate project from Homestead, but shares the BawrLabs platform layer (Ace3, WoW API MCP server, studio workflow). Would be a second addon under the BawrLabs umbrella.
+
+## Awaiting Gate 2
+
+### TRI-003 Colored dispel glow — debuff-type-colored glow animation
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Merged to main, pending in-game verification
+- **Summary:** Current dispel overlay "both" mode shows colored edge border + standard yellow glow. The yellow glow is visually dominant and hides the debuff-type color. Replace with a colored glow that matches the debuff type (blue pulse for Magic, purple for Curse, green for Poison, etc). LibCustomGlow-1.0 supports colored glows via `PixelGlow_Start`, `AutoCastGlow_Start`, and `ButtonGlow_Start` — all accept a color parameter. Cell and HealBot both embed it.
+- **Source:** In-game testing feedback — glow overwhelms border color.
+- **Session progress (2026-04-07):** `LibCustomGlow-1.0` vendored and wired into packaging/load order on worktree branch `tri-003-colored-dispel-glow` (`ccc2fbf`). Integration into `Modules/DispelOverlay.lua` and in-game validation still pending.
+- **Session progress (2026-04-09/11):** Current mainline history is linearized. TRI-003 is on `main` as `53807f4` (`build: vendor LibCustomGlow for colored dispel glow`) and `edb877d` (`feat: integrate colored ButtonGlow into dispel overlay`). Argus QA passed on the vendoring work. Worktree `tri-003-colored-dispel-glow` still exists but is stale.
+- **Next step:** In-game verification on a dispel-capable class.
+
+### TRI-004 Managed frame registry for raid/party/boss frames
+- **Type:** Refactor / Infrastructure
+- **Priority:** High
+- **Status:** Merged to main, pending in-game verification
+- **Summary:** Replace direct Blizzard compact-frame iteration with a central managed-frame registry that tracks frame add/remove/unit-change lifecycle. All modules should query the registry instead of iterating Blizzard raid/party frames directly. This unblocks boss-frame support and future click-casting registration.
+- **Source:** GitHub issue #4.
+- **Session progress (2026-04-07):** Implemented on worktree branch `tri-004-frame-registry` with two local commits: `445d6ff` (`refactor: add managed frame registry`) and `5b51eea` (`fix: support boss units and unnamed managed frames`).
+- **Scope landed on main:** New `Utils/FrameRegistry.lua`; registry-backed iteration and unit lookup across aura listeners, aura indicators, target markers, dispel overlay, range, and stock-aura passes; lifecycle sync from startup, roster changes, and `CompactUnitFrame_SetUnit`; widened default registry support for `boss1..boss5`; unnamed-frame-safe child creation for future addon-owned frames.
+- **Verification:** Argus Gate 1 passed. Current mainline history is linearized; TRI-004 is on `main` as `7eb36f0` (`refactor: add managed frame registry`) and `0588c57` (`fix: support boss units and unnamed managed frames`). Worktree `tri-004-frame-registry` still exists but is stale.
+- **Next step:** In-game Retail verification.
+
+### TRI-007 Test mode — preview frames without a group
+- **Type:** Feature
+- **Priority:** High
+- **Status:** Merged to main, pending in-game verification
+- **Summary:** Preview raid frames without being in a group. Simulated party/raid frames with class colors, health states, aura indicators, power bars, healing-on-click, tooltips. GitHub issue #13.
+- **Implementation:** Current mainline history is linearized. TRI-007 is on `main` as `24248dd`, `ff31723`, `185c6a5`, `c93b4a3`, `886cc61`, `9e75dfa`, and `dbc1a66`. Preview frames are addon-owned and movable, integrate the existing rendering modules through preview-aware adapters, and simulate healing locally.
+- **Gate 1:** Passed. Current mainline hardening commit is `9e75dfa` (earlier branch SHA `f9fc418` is stale after rebase).
+- **Gate 2:** Visual, interaction, and movability fixes landed in `dbc1a66`. Earlier backlog notes that still describe Gate 2 Bug 1 as open are stale.
+- **Next step:** Fresh in-game Retail verification of the merged preview frames.
+
+## Awaiting Release
+
+*(None.)*


### PR DESCRIPTION
## Summary

- Splits Triage-prefixed (TRI-) work out of `BawrLabs/BACKLOG.md` into per-project Tracker + Completed files at the Triage repo root, per STU-034.
- Adds `Tri_Tracker.md` — 26 active items, structured by status with sub-sections under `## Backlog` per the studio default.
- Adds `Tri_Completed.md` — history footer template only (no completed entries yet — Triage's prior work history lives in BawrLabs/BACKLOG.md but no entries there carry the TRI- prefix).
- **Additive only** — this PR does NOT delete `BawrLabs/BACKLOG.md`. Deletion happens in STU-034 PR 3.

## Context

This is **PR 2 of 3** for STU-034. PR 1 (Homestead) already landed at https://github.com/Royaleint/Homestead/pull/34. PR 3 deletes the old `BawrLabs/BACKLOG.md`, rewrites `/end-session` routing, and creates `BawrLabs/INDEX.md`.

Spec: `BawrLabs/plans/STU-034-tracker-split-redesign.md` (BawrLabs commits `5ea4d21`, `f0ba679`, `3c5f6e7`).

## Section counts (Tri_Tracker.md, 26 active items)

| Section | Count |
|---|---|
| Bugs | 1 (TRI-023) |
| Features | 21 |
| Data | 0 |
| Maintenance | 0 |
| Stale | 0 |
| In Progress | 1 (TRI-026) |
| **Awaiting Gate 2** | **3 (TRI-003, TRI-004, TRI-007)** |
| Awaiting Release | 0 |

The three Awaiting Gate 2 items had been buried in the Backlog section of `BawrLabs/BACKLOG.md` with status "Merged to main, pending in-game verification" — exactly the Gate 2 leakage Finding #2 was about. Migration places them correctly.

## Test plan

- [ ] All 26 TRI- item IDs in `BawrLabs/BACKLOG.md` Triage Backlog section appear in `Tri_Tracker.md`
- [ ] No TRI- items appear in `Tri_Completed.md` body (only the footer template)
- [ ] TRI-003, TRI-004, TRI-007 appear in `## Awaiting Gate 2` (not Backlog)
- [ ] TRI-026 appears in `## In Progress`
- [ ] TRI-023 appears under `### Bugs`
- [ ] Anchor links resolve on GitHub web UI for sampled item IDs