### PR TITLE
STU-034 post-merge cleanup — cutover SHA in Tri_Completed footer

### DIFF
--- a/Tri_Completed.md
+++ b/Tri_Completed.md
@@ -9,5 +9,5 @@ is created with the history footer template; entries will be appended as Triage 
 move from `Tri_Tracker.md` to here on completion.)*
 
 ---
-Pre-split history: Royaleint/BawrLabs@<CUTOVER-SHA>:BACKLOG.md
-Archaeology: `git log -S "<ITEM-ID>" -- BACKLOG.md` at that SHA
+Pre-split history: Royaleint/BawrLabs@2951ea8:BACKLOG.md
+Archaeology: `git log -S "<ITEM-ID>" -- BACKLOG.md` at commit 2951ea8^ (the commit before BACKLOG.md was deleted)


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #34 (STU-034 PR 2).

One-line change: replaces the literal \`<CUTOVER-SHA>\` placeholder in Tri_Completed.md footer with BawrLabs PR 3 merge commit \`2951ea8\` (2026-04-20).

Archaeology guidance updated to reference \`2951ea8^\` (the commit immediately before BACKLOG.md was deleted) — that's where \`git log -S\` will actually find TRI- items in the old BACKLOG.md content.

## Test plan

- [ ] Tri_Completed.md footer reads \`Royaleint/BawrLabs@2951ea8:BACKLOG.md\` (no more \`<CUTOVER-SHA>\` placeholder)
- [ ] No other content changes