### PR TITLE
feat(range): extend custom range options to 60 yards

### DIFF
--- a/GUI/GeneralConfigPanel.lua
+++ b/GUI/GeneralConfigPanel.lua
@@ -191,8 +191,7 @@ function EnhancedRaidFrames:CreateGeneralOptions()
 				name = L["Select a Custom Distance"],
 				desc = L["customRangeCheck_desc"],
 				values = { [5] = L["Melee"], [10] = L["10 yards"], [15] = L["15 yards"], [20] = L["20 yards"],
-						   [25] = L["25 yards"], [30] = L["30 yards"], [35] = L["35 yards"], [40] = L["40 yards"],
-						   [45] = L["45 yards"], [50] = L["50 yards"], [55] = L["55 yards"], [60] = L["60 yards"] },
+						   [25] = L["25 yards"], [30] = L["30 yards"], [35] = L["35 yards"], [40] = L["40 yards"] },
 				get = function()
 					return self.db.profile.customRange
 				end,
@@ -280,8 +279,19 @@ function EnhancedRaidFrames:CreateGeneralOptions()
 		}
 	}
 
-	-- Dispel Overlay settings (Retail only)
+	-- Retail-only extensions
 	if not self.isWoWClassicEra and not self.isWoWClassic then
+		-- Extended range options (Retail only) — Classic Era and Pandaria Classic
+		-- healer spells cap at or below 40yd, and LibRangeCheck has no reliable
+		-- checkers beyond that range on those clients. Exposing 45-60yd there
+		-- would produce a setting that silently does nothing and invite bug reports.
+		local customRangeValues = generalOptions.args.customRange.values
+		customRangeValues[45] = L["45 yards"]
+		customRangeValues[50] = L["50 yards"]
+		customRangeValues[55] = L["55 yards"]
+		customRangeValues[60] = L["60 yards"]
+
+		-- Dispel Overlay settings (Retail only)
 		generalOptions.args.dispelOverlayHeader = {
 			type = "header",
 			name = L["Dispel Overlay"],

--- a/GUI/GeneralConfigPanel.lua
+++ b/GUI/GeneralConfigPanel.lua
@@ -9,9 +9,24 @@ local EnhancedRaidFrames = _G.EnhancedRaidFrames
 
 -- Import libraries
 local L = LibStub("AceLocale-3.0"):GetLocale("EnhancedRaidFrames")
+local LibRangeCheck = LibStub("LibRangeCheck-3.0")
 
 -- Constants
 local THIRD_WIDTH = 1.25
+
+-- Warn the user when the selected custom range has no resolvable friend checker
+-- for their current spells. LibRangeCheck builds its checker list from spells
+-- the player actually knows, so picking 55 or 60yd on a spec without a spell
+-- that reaches that range returns nil and Overrides.lua falls back to full
+-- alpha — the frame never dims. Print a message so the behavior isn't silent.
+local function WarnIfNoRangeChecker(self)
+	if not self.db.profile.customRangeCheck then
+		return
+	end
+	if not LibRangeCheck:GetFriendMinChecker(self.db.profile.customRange) then
+		self:Print(L["customRangeUnavailable"]:format(self.db.profile.customRange))
+	end
+end
 
 -------------------------------------------------------------------------
 -------------------------------------------------------------------------
@@ -182,6 +197,7 @@ function EnhancedRaidFrames:CreateGeneralOptions()
 				set = function(_, value)
 					self.db.profile.customRangeCheck = value
 					self:RefreshConfig()
+					WarnIfNoRangeChecker(self)
 				end,
 				width = THIRD_WIDTH,
 				order = 41,
@@ -198,6 +214,7 @@ function EnhancedRaidFrames:CreateGeneralOptions()
 				set = function(_, value)
 					self.db.profile.customRange = value
 					self:RefreshConfig()
+					WarnIfNoRangeChecker(self)
 				end,
 				disabled = function()
 					return not self.db.profile.customRangeCheck

--- a/GUI/GeneralConfigPanel.lua
+++ b/GUI/GeneralConfigPanel.lua
@@ -191,7 +191,8 @@ function EnhancedRaidFrames:CreateGeneralOptions()
 				name = L["Select a Custom Distance"],
 				desc = L["customRangeCheck_desc"],
 				values = { [5] = L["Melee"], [10] = L["10 yards"], [15] = L["15 yards"], [20] = L["20 yards"],
-						   [25] = L["25 yards"], [30] = L["30 yards"], [35] = L["35 yards"], [40] = L["40 yards"] },
+						   [25] = L["25 yards"], [30] = L["30 yards"], [35] = L["35 yards"], [40] = L["40 yards"],
+						   [45] = L["45 yards"], [50] = L["50 yards"], [55] = L["55 yards"], [60] = L["60 yards"] },
 				get = function()
 					return self.db.profile.customRange
 				end,

--- a/Localizations/enUS.lua
+++ b/Localizations/enUS.lua
@@ -119,6 +119,8 @@ L["customRangeCheck_desc"] = "Changes the default 40 yard out-of-range distance 
 L["Out-of-Range Opacity"] = true
 L["rangeAlpha_desc"] = "The opacity percentage of the raid frame when out-of-range"
 
+L["customRangeUnavailable"] = "No range checker available for %d yards with your current spells. Frames will stay visible until you learn a spell that reaches that range or pick a lower distance."
+
 L["Test Mode"] = true
 L["testModeDescription_desc"] = "Spawn synthetic preview frames without joining a real group."
 L["Preview Group Size"] = true

--- a/Localizations/enUS.lua
+++ b/Localizations/enUS.lua
@@ -68,6 +68,10 @@ L["25 yards"] = true
 L["30 yards"] = true
 L["35 yards"] = true
 L["40 yards"] = true
+L["45 yards"] = true
+L["50 yards"] = true
+L["55 yards"] = true
+L["60 yards"] = true
 
 ----------------------------------------------------
 ------------------- General Panel ------------------


### PR DESCRIPTION
## Summary
- Adds 45, 50, 55, and 60 yard buckets to the **Out-of-Range → Select a Custom Distance** selector in `GUI/GeneralConfigPanel.lua` so longer-range healing spells (e.g. Midnight 45–46yd heals) can fade frames at the actual cast boundary instead of being capped at 40.
- Adds the four matching localization keys to `Localizations/enUS.lua` (other locales fall back to enUS).
- Default `customRange = 30` is unchanged, so existing users see no behavioral difference until they pick one of the new options.

## Out of scope
- Auto-detecting the player's longest healing spell range (deferred — would require spec/talent tables).
- Converting the `select` to a free-form slider (would risk passing arbitrary values to `LibRangeCheck:GetFriendMinChecker`).

## Test plan
- [ ] On a healer, enable Custom Range, pick 45/50/55/60 yards, and verify frames fade/un-fade at the chosen distance using `LibRangeCheck-3.0`.
- [ ] Confirm the dispel overlay (`Modules/DispelOverlay.lua`) still hides correctly at extended range.
- [ ] Switch profiles; confirm no DB migration is needed (additive change).

Closes #27

https://claude.ai/code/session_019igm7ooPib6vS42VYF43RM