### PR TITLE
feat(indicators): add 3-way caster filter (All / Mine / Not Mine)

### DIFF
--- a/DatabaseDefaults.lua
+++ b/DatabaseDefaults.lua
@@ -7,7 +7,7 @@
 local EnhancedRaidFrames = _G.EnhancedRaidFrames
 
 -- Latest Database Version (<major>.<minor>)
-EnhancedRaidFrames.DATABASE_VERSION = 2.2
+EnhancedRaidFrames.DATABASE_VERSION = 2.3
 
 -------------------------------------------------------------------------
 -------------------------------------------------------------------------
@@ -83,7 +83,7 @@ function EnhancedRaidFrames:CreateDefaults()
 			auras = "",
 
 			-- Visibility and Behavior
-			mineOnly = false,
+			casterFilter = "all",
 			meOnly = false,
 			missingOnly = false,
 			showTooltip = true,

--- a/GUI/IndicatorConfigPanel.lua
+++ b/GUI/IndicatorConfigPanel.lua
@@ -92,15 +92,18 @@ function EnhancedRaidFrames:CreateIndicatorOptions()
 						name = L["General"],
 						order = 1,
 					},
-					mineOnly = {
-						type = "toggle",
-						name = L["Mine Only"],
-						desc = L["mineOnly_desc"],
+					casterFilter = {
+						type = "select",
+						name = L["Caster Filter"],
+						desc = L["casterFilter_desc"],
+						style = "dropdown",
+						values = { ["all"] = L["All Casters"], ["mine"] = L["Mine Only"], ["notMine"] = L["Not Mine"] },
+						sorting = { [1] = "all", [2] = "mine", [3] = "notMine" },
 						get = function()
-							return self.db.profile["indicator-" .. i].mineOnly
+							return self.db.profile["indicator-" .. i].casterFilter
 						end,
 						set = function(_, value)
-							self.db.profile["indicator-" .. i].mineOnly = value
+							self.db.profile["indicator-" .. i].casterFilter = value
 							self:RefreshConfig()
 						end,
 						width = THIRD_WIDTH,

--- a/Localizations/enUS.lua
+++ b/Localizations/enUS.lua
@@ -165,8 +165,11 @@ L["bleedWildcard_desc"] = "any bleed debuffs (retail only)"
 
 L["Visibility and Behavior"] = true
 
+L["Caster Filter"] = true
+L["casterFilter_desc"] = "Filter the indicator by who cast the aura: any caster, only me, or only other players"
+L["All Casters"] = true
 L["Mine Only"] = true
-L["mineOnly_desc"] = "Only show buffs and debuffs cast by me"
+L["Not Mine"] = true
 
 L["Show On Me Only"] = true
 L["meOnly_desc"] = "Only only show this indicator on myself"

--- a/Modules/AuraIndicators.lua
+++ b/Modules/AuraIndicators.lua
@@ -252,9 +252,12 @@ function EnhancedRaidFrames:ProcessIndicator(indicatorFrame, unit)
 
 	-- Process our visuals
 	if indicatorFrame.thisAura then
-		-- Clear the frame if we're only showing missing auras or we're only showing our own auras and the aura isn't ours
+		-- Clear the frame if we're only showing missing auras or the caster filter rejects the source
+		local casterFilter = self.db.profile["indicator-" .. i].casterFilter
+		local sourceUnit = indicatorFrame.thisAura.sourceUnit
 		if self.db.profile["indicator-" .. i].missingOnly
-				or (self.db.profile["indicator-" .. i].mineOnly and indicatorFrame.thisAura.sourceUnit ~= "player") then
+				or (casterFilter == "mine" and sourceUnit ~= "player")
+				or (casterFilter == "notMine" and (sourceUnit == "player" or sourceUnit == nil)) then
 			self:ClearIndicator(indicatorFrame)
 			return
 		end
@@ -314,9 +317,12 @@ function EnhancedRaidFrames:FindActiveAndTrackedAura(indicatorFrame)
 					-- Check if the aura is a debuff and if the auraString matches one of the debuff type wildcards
 					or (aura.isHarmful and aura.dispelName and aura.dispelName:lower() == auraIdentifier) then
 
-				-- Check if we should only show our own auras
-				if not self.db.profile["indicator-" .. i].mineOnly
-						or (self.db.profile["indicator-" .. i].mineOnly and aura.sourceUnit == "player") then
+				-- Check the caster filter ("all" / "mine" / "notMine"). "notMine" also rejects
+				-- unknown sources (sourceUnit == nil) so server-side or stale auras don't match.
+				local casterFilter = self.db.profile["indicator-" .. i].casterFilter
+				if casterFilter == "all"
+						or (casterFilter == "mine" and aura.sourceUnit == "player")
+						or (casterFilter == "notMine" and aura.sourceUnit ~= nil and aura.sourceUnit ~= "player") then
 					-- Return once we find an aura that matches all of these conditions
 					return aura
 				end

--- a/Utils/DatabaseMigration.lua
+++ b/Utils/DatabaseMigration.lua
@@ -48,6 +48,17 @@ function EnhancedRaidFrames:MigrateDatabase()
 			end
 		end
 
+		-- Added in database version 2.3
+		-- Convert per-indicator boolean `mineOnly` into the new 3-way `casterFilter`
+		-- ("all" | "mine" | "notMine"). Drop the old key once converted.
+		for i = 1, 9 do
+			local indicatorDB = self.db.profile["indicator-" .. i]
+			if indicatorDB and indicatorDB.mineOnly ~= nil then
+				indicatorDB.casterFilter = indicatorDB.mineOnly and "mine" or "all"
+				indicatorDB.mineOnly = nil
+			end
+		end
+
 		-- Reload our database object with the defaults post-migration
 		self:InitializeDatabase()
 


### PR DESCRIPTION
## Summary
Replaces the per-indicator `mineOnly` boolean with a 3-way `casterFilter` select, adding the inverse mode requested in #28. Primary use case: a druid wants to see other druids' Rejuvenation to avoid overwriting them.

### Changes
- `DatabaseDefaults.lua` — `mineOnly = false` → `casterFilter = "all"`. `DATABASE_VERSION` bumped 2.2 → 2.3.
- `Utils/DatabaseMigration.lua` — adds a per-indicator conversion (`true` → `"mine"`, `false` → `"all"`) and clears the old key. Idempotent (only runs while `mineOnly ~= nil`).
- `GUI/IndicatorConfigPanel.lua` — toggle replaced with a dropdown (`All Casters` / `Mine Only` / `Not Mine`).
- `Modules/AuraIndicators.lua` — both filter sites (`ProcessIndicator` and `FindActiveAndTrackedAura`) branch on the enum. `notMine` also rejects auras with unknown `sourceUnit` (`nil`) so server-side or stale auras don't sneak through.
- `Localizations/enUS.lua` — new strings for the dropdown; `mineOnly_desc` removed.

### Out of scope (deferred)
- Visual distinction (glow / border color) for "not mine" vs "mine" when both are tracked in different positions. Marked **Optional** in the issue and would require additional color fields plus a third branch in `UpdateIndicatorColor`.

## Test plan
- [ ] Two druids in a group: cast Rejuv from each, switch the indicator between `All`, `Mine`, `Not Mine`, verify only matching auras render.
- [ ] Load a profile saved on DB v2.2 with `mineOnly = true`; verify the migration rewrites it to `casterFilter = "mine"` and the toggle UI shows the correct selection.
- [ ] Load a profile with `mineOnly = false`; verify it migrates to `"all"`.
- [ ] Confirm `missingOnly` still interacts correctly with the new filter (no regression).
- [ ] Run `luacheck` — already clean locally.

Closes #28

https://claude.ai/code/session_019igm7ooPib6vS42VYF43RM