### PR TITLE
feat(indicators): finer position steps and countdown text anchor

### DIFF
--- a/DatabaseDefaults.lua
+++ b/DatabaseDefaults.lua
@@ -105,6 +105,7 @@ function EnhancedRaidFrames:CreateDefaults()
 			showCountdownText = false,
 			showStackSize = true,
 			stackSizeLocation = "BOTTOMRIGHT",
+			countdownLocation = "CENTER",
 			textColor = { 1, 1, 1, 1 },
 			colorTextByTime = false,
 			colorTextByTime_low = 2,

--- a/GUI/IndicatorConfigPanel.lua
+++ b/GUI/IndicatorConfigPanel.lua
@@ -212,7 +212,7 @@ function EnhancedRaidFrames:CreateIndicatorOptions()
 						isPercent = true,
 						min = -1,
 						max = 1,
-						step = .01,
+						step = .005,
 						get = function()
 							return self.db.profile["indicator-" .. i].indicatorVerticalOffset
 						end,
@@ -230,7 +230,7 @@ function EnhancedRaidFrames:CreateIndicatorOptions()
 						isPercent = true,
 						min = -1,
 						max = 1,
-						step = .01,
+						step = .005,
 						get = function()
 							return self.db.profile["indicator-" .. i].indicatorHorizontalOffset
 						end,
@@ -477,6 +477,26 @@ function EnhancedRaidFrames:CreateIndicatorOptions()
 						end,
 						width = THIRD_WIDTH,
 						order = 5,
+					},
+					countdownLocation = {
+						type = "select",
+						name = L["Countdown Text Location"],
+						desc = L["countdownLocation_desc"],
+						style = "dropdown",
+						values = { ["TOPLEFT"] = L["Top-Left"], ["TOPRIGHT"] = L["Top-Right"], ["BOTTOMLEFT"] = L["Bottom-Left"], ["BOTTOMRIGHT"] = L["Bottom-Right"], ["CENTER"] = L["Center"] },
+						sorting = { [1] = "TOPLEFT", [2] = "TOPRIGHT", [3] = "CENTER", [4] = "BOTTOMLEFT", [5] = "BOTTOMRIGHT" },
+						get = function()
+							return self.db.profile["indicator-" .. i].countdownLocation
+						end,
+						set = function(_, value)
+							self.db.profile["indicator-" .. i].countdownLocation = value
+							self:RefreshConfig()
+						end,
+						disabled = function()
+							return not self.db.profile["indicator-" .. i].showCountdownText
+						end,
+						width = THIRD_WIDTH,
+						order = 6,
 					},
 					-------------------------------------------------
 					colorHeader = {

--- a/Localizations/enUS.lua
+++ b/Localizations/enUS.lua
@@ -216,6 +216,9 @@ L["countdownTextSize_desc"] = "The size of the countdown text (in pixels)"
 L["Stack Size Location"] = true
 L["stackSizeLocation_desc"] = "The location of the stack size text within the indicator"
 
+L["Countdown Text Location"] = true
+L["countdownLocation_desc"] = "The location of the countdown text within the indicator"
+
 L["Text Color"] = true
 L["textColor_desc1"] = "The color used for the countdown text"
 L["textColor_desc2"] = "unless augmented by other text color options"

--- a/Modules/AuraIndicators.lua
+++ b/Modules/AuraIndicators.lua
@@ -423,14 +423,13 @@ function EnhancedRaidFrames:UpdateStackSizeText(indicatorFrame)
 	-- of the stack size. ClearAllPoints first so switching between corners
 	-- doesn't accumulate stale anchors on the FontString.
 	indicatorFrame.Countdown:ClearAllPoints()
-	local countdownLocation = self.db.profile["indicator-" .. i].countdownLocation
-	if countdownLocation == "TOPLEFT" then
+	if self.db.profile["indicator-" .. i].countdownLocation == "TOPLEFT" then
 		indicatorFrame.Countdown:SetPoint("TOPLEFT", indicatorFrame, "TOPLEFT", 1, -1)
-	elseif countdownLocation == "TOPRIGHT" then
+	elseif self.db.profile["indicator-" .. i].countdownLocation == "TOPRIGHT" then
 		indicatorFrame.Countdown:SetPoint("TOPRIGHT", indicatorFrame, "TOPRIGHT", -1, -1)
-	elseif countdownLocation == "BOTTOMLEFT" then
+	elseif self.db.profile["indicator-" .. i].countdownLocation == "BOTTOMLEFT" then
 		indicatorFrame.Countdown:SetPoint("BOTTOMLEFT", indicatorFrame, "BOTTOMLEFT", 1, 1)
-	elseif countdownLocation == "BOTTOMRIGHT" then
+	elseif self.db.profile["indicator-" .. i].countdownLocation == "BOTTOMRIGHT" then
 		indicatorFrame.Countdown:SetPoint("BOTTOMRIGHT", indicatorFrame, "BOTTOMRIGHT", -1, 1)
 	else -- "CENTER"
 		indicatorFrame.Countdown:SetPoint("CENTER", indicatorFrame, "CENTER", 0, 0)

--- a/Modules/AuraIndicators.lua
+++ b/Modules/AuraIndicators.lua
@@ -419,31 +419,37 @@ function EnhancedRaidFrames:UpdateStackSizeText(indicatorFrame)
 	local i = indicatorFrame.position
 	local thisAura = indicatorFrame.thisAura
 
+	-- Anchor the Countdown text based on its own location setting, independent
+	-- of the stack size. ClearAllPoints first so switching between corners
+	-- doesn't accumulate stale anchors on the FontString.
+	indicatorFrame.Countdown:ClearAllPoints()
+	local countdownLocation = self.db.profile["indicator-" .. i].countdownLocation
+	if countdownLocation == "TOPLEFT" then
+		indicatorFrame.Countdown:SetPoint("TOPLEFT", indicatorFrame, "TOPLEFT", 1, -1)
+	elseif countdownLocation == "TOPRIGHT" then
+		indicatorFrame.Countdown:SetPoint("TOPRIGHT", indicatorFrame, "TOPRIGHT", -1, -1)
+	elseif countdownLocation == "BOTTOMLEFT" then
+		indicatorFrame.Countdown:SetPoint("BOTTOMLEFT", indicatorFrame, "BOTTOMLEFT", 1, 1)
+	elseif countdownLocation == "BOTTOMRIGHT" then
+		indicatorFrame.Countdown:SetPoint("BOTTOMRIGHT", indicatorFrame, "BOTTOMRIGHT", -1, 1)
+	else -- "CENTER"
+		indicatorFrame.Countdown:SetPoint("CENTER", indicatorFrame, "CENTER", 0, 0)
+	end
+
 	-- Set the stack count text
 	if self.db.profile["indicator-" .. i].showStackSize and thisAura.applications and thisAura.applications > 1 then
-		-- Set the position of the stack size text based on the user's choice
-		-- Since space is limited, we have to move the countdown text to make room for the stack size text
+		indicatorFrame.StackSize:ClearAllPoints()
 		if self.db.profile["indicator-" .. i].stackSizeLocation == "TOPLEFT" then
-			indicatorFrame.StackSize:ClearAllPoints()
 			indicatorFrame.StackSize:SetPoint("TOPLEFT", indicatorFrame, "TOPLEFT", -3, 2)
-			indicatorFrame.Countdown:SetPoint("CENTER", indicatorFrame, "CENTER", 1, -1)
 		elseif self.db.profile["indicator-" .. i].stackSizeLocation == "TOPRIGHT" then
-			indicatorFrame.StackSize:ClearAllPoints()
 			indicatorFrame.StackSize:SetPoint("TOPRIGHT", indicatorFrame, "TOPRIGHT", 4, 2)
-			indicatorFrame.Countdown:SetPoint("CENTER", indicatorFrame, "CENTER", -1, -1)
 		elseif self.db.profile["indicator-" .. i].stackSizeLocation == "BOTTOMLEFT" then
-			indicatorFrame.StackSize:ClearAllPoints()
 			indicatorFrame.StackSize:SetPoint("BOTTOMLEFT", indicatorFrame, "BOTTOMLEFT", -3, -2)
-			indicatorFrame.Countdown:SetPoint("CENTER", indicatorFrame, "CENTER", 1, 1)
 		elseif self.db.profile["indicator-" .. i].stackSizeLocation == "BOTTOMRIGHT" then
-			indicatorFrame.StackSize:ClearAllPoints()
 			indicatorFrame.StackSize:SetPoint("BOTTOMRIGHT", indicatorFrame, "BOTTOMRIGHT", 4, -2)
-			indicatorFrame.Countdown:SetPoint("CENTER", indicatorFrame, "CENTER", -1, 1)
 		end
 		indicatorFrame.StackSize:SetText(thisAura.applications)
 	else
-		-- Reset the position of the countdown text and clear our stack size text
-		indicatorFrame.Countdown:SetPoint("CENTER", indicatorFrame, "CENTER", 0, 0)
 		indicatorFrame.StackSize:SetText("")
 	end
 end


### PR DESCRIPTION
## Summary
Two small positioning improvements for indicator config, both self-contained.

### 1. Finer offset increments
`GUI/IndicatorConfigPanel.lua` — `indicatorVerticalOffset` and `indicatorHorizontalOffset` sliders now step at **0.5%** (was 1%). AceConfig's `range` widget still supports typed-in values anywhere in `[-1, 1]`, so users who want an exact percentage can click the value and type it.

### 2. Independent countdown text anchor
New per-indicator dropdown **Countdown Text Location** with the five options `Top-Left`, `Top-Right`, `Center`, `Bottom-Left`, `Bottom-Right`. Today the countdown is always centered (with a small nudge away from the stack-size corner), so users who want to display both stack count *and* countdown can't separate them spatially. This PR decouples them.

**Implementation:**
- `DatabaseDefaults.lua` — adds `countdownLocation = "CENTER"` alongside the existing `stackSizeLocation` default. This reproduces today's visual behavior, so AceDB's defaults-merge handles old profiles automatically.
- `GUI/IndicatorConfigPanel.lua` — new `select` next to `stackSizeLocation` (`order = 6`), disabled when `showCountdownText` is off for consistency with `textSize`.
- `Modules/AuraIndicators.lua` — `UpdateStackSizeText` rewritten to anchor the Countdown FontString based on `countdownLocation`, independent of stack size. Also adds `ClearAllPoints()` before each `SetPoint` so switching corners doesn't accumulate stale anchors (latent issue in the old code that only happened not to bite because CENTER was re-used).
- `Localizations/enUS.lua` — `Countdown Text Location` and `countdownLocation_desc`. `L["Center"]` already exists (raid-frame POSITION label).

### Client compatibility
No gating — `SetPoint` and AceConfig step behavior are identical on Classic Era, Pandaria Classic, and Retail.

### DB migration
**None required.** New key has a safe default that matches current behavior; old profiles pick it up via AceDB defaults merge.

### Out of scope
- "Manual numeric input" request from the issue body — AceConfig's `range` widget already supports this via click-to-type; no extra code needed.
- Stack / countdown conflict resolution (auto-push one out of the way when user picks the same corner) — left as user's choice; they can pick complementary corners.

## Test plan
- [ ] Fresh install: verify indicators render identically to current behavior (countdown centered, stack at bottom-right) using test mode `/triage test`.
- [ ] Move the vertical/horizontal offset sliders with arrow keys — verify 0.5% ticks.
- [ ] Set stack location `TOPRIGHT` and countdown location `BOTTOMLEFT`; verify both render in their corners without overlap.
- [ ] Set both to `BOTTOMRIGHT`; verify overlap (user's choice, expected).
- [ ] Toggle `Show Countdown Text` off; verify the dropdown disables.
- [ ] Load a pre-existing profile from main (no `countdownLocation` key) — verify it picks up `"CENTER"` default and nothing breaks.
- [ ] `luacheck` — clean locally.

Closes #30

https://claude.ai/code/session_019igm7ooPib6vS42VYF43RM