### PR TITLE
feat(range): per-profile toggle to keep indicators visible out of range

### DIFF
--- a/DatabaseDefaults.lua
+++ b/DatabaseDefaults.lua
@@ -45,6 +45,7 @@ function EnhancedRaidFrames:CreateDefaults()
 		customRangeCheck = false,
 		customRange = 30,
 		rangeAlpha = 0.55,
+		keepIndicatorsVisible = false,
 
 		-------------------------------
 		---- Dispel Overlay (Retail) ---

--- a/GUI/GeneralConfigPanel.lua
+++ b/GUI/GeneralConfigPanel.lua
@@ -223,6 +223,20 @@ function EnhancedRaidFrames:CreateGeneralOptions()
 				width = THIRD_WIDTH,
 				order = 43,
 			},
+			keepIndicatorsVisible = {
+				type = "toggle",
+				name = L["Keep Indicators Visible Out of Range"],
+				desc = L["keepIndicatorsVisible_desc"],
+				get = function()
+					return self.db.profile.keepIndicatorsVisible
+				end,
+				set = function(_, value)
+					self.db.profile.keepIndicatorsVisible = value
+					self:RefreshConfig()
+				end,
+				width = THIRD_WIDTH,
+				order = 44,
+			},
 			testModeHeader = {
 				type = "header",
 				name = L["Test Mode"],

--- a/Localizations/enUS.lua
+++ b/Localizations/enUS.lua
@@ -115,6 +115,9 @@ L["customRangeCheck_desc"] = "Changes the default 40 yard out-of-range distance 
 L["Out-of-Range Opacity"] = true
 L["rangeAlpha_desc"] = "The opacity percentage of the raid frame when out-of-range"
 
+L["Keep Indicators Visible Out of Range"] = true
+L["keepIndicatorsVisible_desc"] = "Keep aura indicators at full opacity when the raid frame fades out of range. Requires Override Default Distance to be enabled."
+
 L["Test Mode"] = true
 L["testModeDescription_desc"] = "Spawn synthetic preview frames without joining a real group."
 L["Preview Group Size"] = true

--- a/Modules/AuraIndicators.lua
+++ b/Modules/AuraIndicators.lua
@@ -84,6 +84,15 @@ function EnhancedRaidFrames:SetIndicatorAppearance(frame)
 		indicatorFrame:SetWidth(self.db.profile["indicator-" .. i].indicatorSize)
 		indicatorFrame:SetHeight(self.db.profile["indicator-" .. i].indicatorSize)
 
+		-- Keep indicators at full alpha when the parent raid frame fades out of range.
+		-- Only meaningful when Custom Range is enabled — Blizzard's default 40yd fade
+		-- uses a secret-tainted alpha path we can't override (see Overrides.lua
+		-- UpdateInRange). Defensive method check covers older clients that may lack
+		-- SetIgnoreParentAlpha.
+		if indicatorFrame.SetIgnoreParentAlpha then
+			indicatorFrame:SetIgnoreParentAlpha(self.db.profile.keepIndicatorsVisible)
+		end
+
 		--------------------------------------
 
 		-- Set the indicator frame position


### PR DESCRIPTION
## Summary
When a player is out of range, the raid frame fades to the user-configured `rangeAlpha`. Aura indicators are `SetParent`ed to the raid frame (`Modules/AuraIndicators.lua:31,35`), so they inherit the faded alpha — exactly when healers most want the information. This PR adds a per-profile toggle that keeps the indicator icons at their own alpha when the parent frame fades.

### Implementation
- **`DatabaseDefaults.lua`** — new `keepIndicatorsVisible = false` under the Out-of-Range Options block. Default preserves existing behavior.
- **`GUI/GeneralConfigPanel.lua`** — new toggle in the `outOfRangeOptions` group right after `rangeAlpha` (`order = 44`).
- **`Modules/AuraIndicators.lua`** — `SetIndicatorAppearance` calls `indicatorFrame:SetIgnoreParentAlpha(self.db.profile.keepIndicatorsVisible)`. This sits on the setup/refresh path so mid-session toggle works without `/reload` (`RefreshConfig → UpdateIndicators(frame, true) → SetIndicatorAppearance`).
- **Defensive method check** — `if indicatorFrame.SetIgnoreParentAlpha then` matches the pattern used by `SetPropagateMouseClicks` in `SetMouseBehavior` (`Modules/AuraIndicators.lua:176`). Harmless no-op on any client that lacks the API.
- **`Localizations/enUS.lua`** — `Keep Indicators Visible Out of Range` + description that explicitly calls out the `Override Default Distance` dependency.

### Why `SetIgnoreParentAlpha` vs counter-alpha polling
- Cleaner: one line on the setup path vs a new polling loop that fights whatever alpha Blizzard/LibRangeCheck sets.
- No fragility around update order with `Overrides.lua:UpdateInRange`.
- Zero runtime cost once set.

### Client compatibility
`SetIgnoreParentAlpha` has been standard on Frame/Region objects since Legion (7.0) and is present on all three supported clients (Classic Era 1.15+, Pandaria Classic 5.5+, Retail 12.0+). The defensive guard is belt-and-suspenders only.

### DB migration
**None required.** New key with a default value that matches today's behavior; AceDB's defaults merge handles old profiles automatically.

### Known limitation (documented in setting description)
The toggle only has visible effect when **Override Default Distance** is enabled. Blizzard's default 40yd fade uses a secret-tainted alpha path (`frame.outOfRange` broken by C_Secrets in Midnight) that addons cannot intercept — this is the same limitation that already constrains `rangeAlpha`, noted in `Overrides.lua:132-137`.

### Out of scope
- Per-indicator override (issue explicitly calls for profile-level only).
- Working around Blizzard's default-range dimming — blocked upstream by C_Secrets.

## Test plan
- [ ] Enable **Override Default Distance** with Custom Range = 30yd and `rangeAlpha = 0.3`. Walk out of range. With the toggle **off**: indicators fade with the frame. With the toggle **on**: indicators stay at full alpha while the frame dims.
- [ ] Toggle mid-session without reloading; confirm existing indicator frames update immediately via `RefreshConfig`.
- [ ] Toggle **on** with default range (customRangeCheck=false); confirm no regression (Blizzard's own dimming continues to apply to everything — expected).
- [ ] Load a pre-existing profile without `keepIndicatorsVisible`; confirm default `false` is applied and behavior is unchanged.
- [ ] `luacheck` — clean locally.

Closes #31

https://claude.ai/code/session_019igm7ooPib6vS42VYF43RM